### PR TITLE
Refactor: change data type of grid to Uint8

### DIFF
--- a/gameOfLife.h
+++ b/gameOfLife.h
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <stdbool.h>
+#include <stdint.h>
 
 #include <SDL2/SDL.h>
 
@@ -17,11 +18,11 @@
 #define M HEIGHT / CELLWIDTH
 #define N WIDTH / CELLWIDTH
 
-void copyMatrix(int copy[M][N], int matrix[M][N]);
+void copyMatrix(Uint8 copy[M][N], Uint8 matrix[M][N]);
+int countNeighbors(int rowIndex, int colIndex, Uint8 matrix[M][N]);
 int isValidcell(int row, int col);
-int countNeighbors(int rowIndex, int colIndex, int matrix[M][N]);
-void printMatrix(int matrix[M][N]);
-void handleLogic(int matrix[M][N], int new_matrix[M][N]);
+void printMatrix(Uint8 matrix[M][N]);
+void handleLogic(Uint8 matrix[M][N], Uint8 new_matrix[M][N]);
 
 
 #endif // GAMEOFLIFE_H_

--- a/main.c
+++ b/main.c
@@ -1,7 +1,7 @@
 #include "gameOfLife.h"
 
 bool gameLoopRunning = true;
-int matrix[M][N] = { 0 };
+Uint8 matrix[M][N] = { 0 };
 bool leftMouseButtonDown = false;
 int k = 0;
 
@@ -19,7 +19,7 @@ void drawGrid(SDL_Surface* surface) {
     }
 }
 
-void drawMatrix(SDL_Surface* surface, int matrix[M][N]) {
+void drawMatrix(SDL_Surface* surface, Uint8 matrix[M][N]) {
     for(int i = 0; i < M; i++) {
         for(int j = 0; j < N; j++) {
             if(matrix[i][j]) {
@@ -76,7 +76,7 @@ void handleEvents() {
 
 int processGame(int k) {
     if (k > GAME_SPEED) {
-        int new_matrix[M][N] = { 0 };
+        Uint8 new_matrix[M][N] = { 0 };
         handleLogic(matrix, new_matrix);
         copyMatrix(matrix, new_matrix);
         return 0;

--- a/utils.c
+++ b/utils.c
@@ -1,6 +1,6 @@
 #include "gameOfLife.h"
 
-void copyMatrix(int copy[M][N], int matrix[M][N]) {
+void copyMatrix(Uint8 copy[M][N], Uint8 matrix[M][N]) {
 	for (int i = 0; i < M; i++) {
 		for (int j = 0; j < N; j++)
 			copy[i][j] = matrix[i][j];
@@ -13,7 +13,7 @@ int isValidcell(int row, int col) {
 	return 1;
 }
 
-int countNeighbors(int rowIndex, int colIndex, int matrix[M][N]) {
+int countNeighbors(int rowIndex, int colIndex, Uint8 matrix[M][N]) {
 	int offset[8][2] = {
 		{-1,-1},
 		{-1,0},
@@ -34,7 +34,7 @@ int countNeighbors(int rowIndex, int colIndex, int matrix[M][N]) {
 	return sum;
 }
 
-void printMatrix(int matrix[M][N]) {
+void printMatrix(Uint8 matrix[M][N]) {
 	for(int i = 0; i < M; i++) {
 		for(int j = 0; j < N; j++)
 			printf("%d ", matrix[i][j]);
@@ -43,7 +43,7 @@ void printMatrix(int matrix[M][N]) {
 	printf("================================================\n");
 }
 
-void handleLogic(int matrix[M][N], int new_matrix[M][N]) {
+void handleLogic(Uint8 matrix[M][N], Uint8 new_matrix[M][N]) {
 
 	int count = 0;
 


### PR DESCRIPTION
- Changed the 2D array type from `int` to `Uint8` to optimize memory usage.
- This change should reduce memory consumption as the values only need 1 byte instead of 4.
- No other functionality is affected.
- Closes #2  (Change data types)
